### PR TITLE
fix JavaScript format in Theme Switcher

### DIFF
--- a/lib/sutra_ui/theme_switcher.ex
+++ b/lib/sutra_ui/theme_switcher.ex
@@ -169,8 +169,8 @@ defmodule SutraUI.ThemeSwitcher do
       </span>
     </button>
 
-    <script :type={ColocatedHook} name=".ThemeSwitcher" runtime>
-      {
+    <script :type={ColocatedHook} name=".ThemeSwitcher">
+      export default {
         mounted() {
           // Handle click events to toggle theme
           // Check current theme and toggle to the opposite


### PR DESCRIPTION
I was having trouble getting the theme switcher to work with the newest Phoenix.  After digging around, I determined that it had to do with using the runtime attribute and my Content Security Policy.

This worked to fix it for me.  Does this look right?  Or is there a reason we need this to be registered at runtime?